### PR TITLE
Move xrootd ref lsst-dev -> master

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -67,9 +67,7 @@ astshim: https://github.com/lsst/astshim.git
 sconsUtils: https://github.com/lsst/sconsUtils.git
 afw: https://github.com/lsst/afw.git
 meas_base: https://github.com/lsst/meas_base.git
-xrootd:
-  url: https://github.com/lsst/xrootd.git
-  ref: lsst-dev
+xrootd: https://github.com/lsst/xrootd.git
 apr_util: https://github.com/lsst/apr_util.git
 daf_persistence: https://github.com/lsst/daf_persistence.git
 obs_lsstSim: https://github.com/lsst/obs_lsstSim.git


### PR DESCRIPTION
XRootD SSI V2 is now on upstream master.  Cutting ref over to start
building from master on our fork (requires parallel change in Qserv;
coordinating ticket is DM-9737.)