### PR TITLE
Add three packages used for very old versions of code

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -329,3 +329,6 @@ sims_seeingModel: https://github.com/lsst/sims_seeingModel.git
 json_nlohmann: https://github.com/lsst/json_nlohmann.git
 display_ginga: https://github.com/lsst/display_ginga
 cbp: https://github.com/lsst/cbp
+meas_extensions_multiShapelet: https://github.com/lsst-dm/legacy-meas_extensions_multiShapelet.git
+testing_pipeQA: https://github.com/lsst/testing_pipeQA.git
+testing_displayQA: https://github.com/lsst/testing_displayQA.git


### PR DESCRIPTION
These are needed to allow lsst_distrib v7.2 to v9.2 to be cloned.