### PR TITLE
DM-15142: Create CI-sized DECam Dataset

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -358,3 +358,12 @@ ts_proposalScheduler: https://github.com/lsst-ts/ts_proposalScheduler.git
 sims_featureScheduler: https://github.com/lsst/sims_featureScheduler.git
 sims_ocs: https://github.com/lsst-sims/sims_ocs.git
 obs_metadata: https://github.com/lsst/obs_metadata.git
+ap_verify_testdata:
+  url: https://github.com/lsst-dm/ap_verify_testdata.git
+  lfs: true
+ap_verify_hits2015:
+  url: https://github.com/lsst/ap_verify_hits2015.git
+  lfs: true
+ap_verify_ci_hits2015:
+  url: https://github.com/lsst/ap_verify_ci_hits2015.git
+  lfs: true


### PR DESCRIPTION
This PR enables `lsstsw` installation of `ap_verify` datasets. Accidental downloads of Git LFS repositories are blocked by lsst/lsstsw#227.

Note: while a review is not, in general, required for changes to `repos.yaml`, I would like these changes to be reviewed in the context of the other DM-15142 work.