### PR TITLE
DM-14273: Add ap_verify to lsst_distrib

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -358,8 +358,11 @@ ts_proposalScheduler: https://github.com/lsst-ts/ts_proposalScheduler.git
 sims_featureScheduler: https://github.com/lsst/sims_featureScheduler.git
 sims_ocs: https://github.com/lsst-sims/sims_ocs.git
 obs_metadata: https://github.com/lsst/obs_metadata.git
+ap_association: https://github.com/lsst/ap_association.git
+ap_pipe: https://github.com/lsst/ap_pipe.git
+ap_verify: https://github.com/lsst/ap_verify.git
 ap_verify_testdata:
-  url: https://github.com/lsst-dm/ap_verify_testdata.git
+  url: https://github.com/lsst/ap_verify_testdata.git
   lfs: true
 ap_verify_hits2015:
   url: https://github.com/lsst/ap_verify_hits2015.git


### PR DESCRIPTION
This PR adds the `ap_*` packages that were newly added to the `lsst` organization. Note that these packages cannot yet be automatically downloaded, as they depend on the unregistered `l1dbproto` package. This dependency will be taken care of by [DM-15775](https://jira.lsstcorp.org/browse/DM-15775).