### PR TITLE
DM-15775: Add dax_ppdb to the Stack.

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -370,3 +370,4 @@ ap_verify_hits2015:
 ap_verify_ci_hits2015:
   url: https://github.com/lsst/ap_verify_ci_hits2015.git
   lfs: true
+dax_ppdb: https://github.com/lsst/dax_ppdb.git


### PR DESCRIPTION
This PR adds `dax_ppdb` so that it can be built with normal Stack installation tools. All dependencies are already present.