### PR TITLE
tickets/DM-19817 Add repos for decoupled ci_hsc

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -393,3 +393,8 @@ obs_decam_data: https://github.com/lsst/obs_decam_data.git
 obs_subaru_data: https://github.com/lsst/obs_subaru_data.git
 obs_lsst_data: https://github.com/lsst/obs_lsst_data.git
 obs_test_data: https://github.com/lsst/obs_test_data.git
+testdata_ci_hsc:
+  url: https://github.com/lsst/testdata_ci_hsc.git
+  lfs: true
+ci_hsc_gen2: https://github.com/lsst/ci_hsc_gen2.git
+ci_hsc_gen3: https://github.com/lsst/ci_hsc_gen3.git


### PR DESCRIPTION
Tickets/DM-19817 decoupled the data from ci_hsc, renamed the code
part to ci_hsc_gen2, and introduced a ci_hsc_gen3 package. This
commit adds them into the repos.yaml file.