### PR TITLE
DM-24259: Create “stub“ Gen2 HSC dataset for CI testing

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -380,6 +380,9 @@ ap_verify_hits2015:
 ap_verify_ci_hits2015:
   url: https://github.com/lsst/ap_verify_ci_hits2015.git
   lfs: true
+ap_verify_ci_cosmos_pdr2:
+  url: https://github.com/lsst/ap_verify_ci_cosmos_pdr2.git
+  lfs: true
 python_py: https://github.com/lsst/python_py.git
 obs_lsst: https://github.com/lsst/obs_lsst.git
 ctrl_mpexec: https://github.com/lsst/ctrl_mpexec.git


### PR DESCRIPTION
This PR adds the `ap_verify_ci_cosmos_pdr2` Git LFS repository.