### PR TITLE
Move the git repository to legacy status

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -140,7 +140,7 @@ h5py: https://github.com/lsst/h5py.git
 obs_sdss: https://github.com/lsst/obs_sdss.git
 activemqcpp: https://github.com/lsst-dm/legacy-activemqcpp.git
 pex_harness: https://github.com/lsst-dm/legacy-pex_harness.git
-git: https://github.com/lsst/git.git
+git: https://github.com/lsst-dm/legacy-git.git
 sims_catUtils: https://github.com/lsst/sims_catUtils.git
 sims_alertsim: https://github.com/lsst-sims/sims_alertsim.git
 sims_GalSimInterface: https://github.com/lsst/sims_GalSimInterface.git


### PR DESCRIPTION
We no longer use it, and it contains an old/obsolete version of git.