### PR TITLE
DM-32345: Add cell_coadds package.

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -444,3 +444,4 @@ cp_verify: https://github.com/lsst/cp_verify.git
 spectractor: https://github.com/lsst/Spectractor.git
 drp_pipe: https://github.com/lsst/drp_pipe.git
 resources: https://github.com/lsst/resources.git
+cell_coadds: https://github.com/lsst-dm/cell_coadds.git


### PR DESCRIPTION
Should have been done with the rest of the DM-32345 merge, but it's only a matter of convenience anyway, as this is a prototype in lsst-dm that can currently do complete CI in GHA, so Jenkins is unnecessary.