### PR TITLE
DM-36477: Remove ap_verify_hits2015 dataset

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,22 +1,11 @@
 name: lint
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-
-      - name: Install
-        run: pip install -r <(curl https://raw.githubusercontent.com/lsst/linting/main/requirements.txt)
-
-      - name: Run linter
-        run: flake8
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main

--- a/.github/workflows/repos.yaml
+++ b/.github/workflows/repos.yaml
@@ -10,12 +10,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install
         run: pip install -r requirements.txt

--- a/.github/workflows/repos.yaml
+++ b/.github/workflows/repos.yaml
@@ -1,8 +1,10 @@
 name: repos
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,22 +1,11 @@
 name: Lint YAML Files
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-
-      - name: Install
-        run: pip install yamllint
-
-      - name: Run linter
-        run: yamllint .
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/yamllint.yaml@main

--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -387,7 +387,7 @@ ap_verify_testdata:
   url: https://github.com/lsst/ap_verify_testdata.git
   lfs: true
 ap_verify_hits2015:
-  url: https://github.com/lsst/ap_verify_hits2015.git
+  url: https://github.com/lsst-dm/legacy-ap_verify_hits2015.git
   lfs: true
 ap_verify_ci_hits2015:
   url: https://github.com/lsst/ap_verify_ci_hits2015.git

--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -395,6 +395,9 @@ ap_verify_ci_hits2015:
 ap_verify_ci_cosmos_pdr2:
   url: https://github.com/lsst/ap_verify_ci_cosmos_pdr2.git
   lfs: true
+ap_verify_ci_dc2:
+  url: https://github.com/lsst/ap_verify_ci_dc2.git
+  lfs: true
 python_py: https://github.com/lsst-dm/legacy-python_py.git
 obs_lsst: https://github.com/lsst/obs_lsst.git
 ctrl_mpexec: https://github.com/lsst/ctrl_mpexec.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansicolors==1.0.2
-PyYAML>=4.2b4,<6
+PyYAML>=6,<7
 urllib3>=1.25.11,<2


### PR DESCRIPTION
This PR updates the `repos.yaml` entry for `ap_verify_hits2015`, per the procedure at https://developer.lsst.io/stack/deprecating-interfaces.html#package-removal. It also adds an entry for `ap_verify_ci_dc2`, which was overlooked when that package was added.