### PR TITLE
DM-43097: Re-introduce dax_ppdb package

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -419,7 +419,7 @@ testdata_ci_hsc:
 ci_hsc_gen2: https://github.com/lsst-dm/legacy-ci_hsc_gen2.git
 ci_hsc_gen3: https://github.com/lsst/ci_hsc_gen3.git
 dax_apdb: https://github.com/lsst/dax_apdb.git
-dax_ppdb: https://github.com/lsst/dax_apdb.git
+dax_ppdb: https://github.com/lsst/dax_ppdb.git
 hiredis: https://github.com/lsst/hiredis
 redis_plus_plus: https://github.com/lsst/redis_plus_plus
 alert_packet: https://github.com/lsst/alert_packet.git


### PR DESCRIPTION
The package will hold tools for APDB-to-PPDB replication.