### PR TITLE
Remove lsst_testsonly repository entry

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -513,6 +513,5 @@ descwl_shear_sims:
 metadetect:
   url: https://github.com/lsst/metadetect
   ref: lsst-dev
-lsst_testsonly: https://github.com/lsst/lsst_testsonly
 lsst_extras: https://github.com/lsst/lsst_extras
 dax_ppdbx_gcp: https://github.com/lsst-dm/dax_ppdbx_gcp


### PR DESCRIPTION
Removed the lsst_testsonly repository entry from the YAML file.

Reverses #176.